### PR TITLE
Add historical one call API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ExOwm.get_historical_weather([%{lat: 52.374031, lon: 4.88969, dt: yesterday}])
 
 Please refer to official [docs](https://hexdocs.pm/ex_owm/readme.html) for more details.
 
-## Overivew
+## Overview
 
 ExOwm is using cool features like:
 

--- a/README.md
+++ b/README.md
@@ -28,31 +28,17 @@ If you are going to use this application as a dependency in your own project, yo
 
 ```elixir
 config :ex_owm, api_key: System.get_env("OWM_API_KEY")
-
-config :ex_owm, ExOwm.CurrentWeather.Cache,
-  adapter: Nebulex.Adapters.Local,
-  n_shards: 2,
-  gc_interval: 3600
-
-config :ex_owm, ExOwm.FiveDayForecast.Cache,
-  adapter: Nebulex.Adapters.Local,
-  n_shards: 2,
-  gc_interval: 3600
-
-config :ex_owm, ExOwm.SixteenDayForecast.Cache,
-  adapter: Nebulex.Adapters.Local,
-  n_shards: 2,
-  gc_interval: 3600
 ```
 
 ..and you are ready to go!
 
 ## Basic Usage
 
-ExOwm is currently handling three main OpenWeatherMap [APIs](http://openweathermap.org/api):
+ExOwm is currently handling the following main OpenWeatherMap [APIs](http://openweathermap.org/api):
 
 *   [Current weather data](http://openweathermap.org/current)
 *   [One Call API](https://openweathermap.org/api/one-call-api)
+*   [One Call API History](https://openweathermap.org/api/one-call-api#history)
 *   [5 day / 3 hour forecast](http://openweathermap.org/forecast5)
 *   [1 - 16 day / daily forecast](http://openweathermap.org/forecast16)
 
@@ -70,6 +56,11 @@ ExOwm.get_five_day_forecast([%{city: "Warsaw"}, %{city: "London", country_code: 
 
 ExOwm.get_sixteen_day_forecast([%{city: "Warsaw"}, %{city: "unknown City Name", country_code: "uk"}], units: :metric, lang: :pl, cnt: 16)
 [{:ok, %{WARSAW_DATA}}, {:error, :not_found, %{"cod" => "404", "message" => "city not found"}}]
+
+yesterday = DateTime.utc_now() |> DateTime.add(24 * 60 * 60 * -1, :second) |> DateTime.to_unix()
+ExOwm.get_historical_weather([%{lat: 52.374031, lon: 4.88969, dt: yesterday}])
+[{:ok, %{CITY_DATA}}]
+
 ```
 
 Please refer to official [docs](https://hexdocs.pm/ex_owm/readme.html) for more details.

--- a/lib/ex_owm.ex
+++ b/lib/ex_owm.ex
@@ -14,6 +14,7 @@ defmodule ExOwm do
           | %{city: String.t(), country_code: String.t()}
           | %{id: integer()}
           | %{lat: float(), lon: float()}
+          | %{lat: float(), lon: float(), dt: integer()}
           | %{zip: String.t(), country_code: String.t()}
 
   @typedoc """
@@ -106,4 +107,24 @@ defmodule ExOwm do
 
   def get_sixteen_day_forecast(location, opts) when is_map(location),
     do: get_sixteen_day_forecast([location], opts)
+
+  @doc """
+  Gets historical weather data of the given location with specified options.
+  dt should be within the last 5 days.
+
+  ## Examples
+
+      iex> ExOwm.get_historical_weather([%{lat: 52.374031, lon: 4.88969, dt: 1615546800}], units: :metric, lang: :pl)
+
+  """
+  @spec get_historical_weather(requests, options) :: map
+  def get_historical_weather(loc, opts \\ [])
+
+  def get_historical_weather(locations, opts) when is_list(locations) do
+    ExOwm.HistoricalWeather.Coordinator.get_weather(locations, opts)
+  end
+
+  def get_historical_weather(location, opts) when is_map(location),
+      do: get_historical_weather([location], opts)
+
 end

--- a/lib/ex_owm/api.ex
+++ b/lib/ex_owm/api.ex
@@ -28,6 +28,7 @@ defmodule ExOwm.Api do
 
       {:ok, %HTTPoison.Response{status_code: 401, body: json_body}} ->
         {:error, :api_key_invalid, json_body}
+      error -> error
     end
   end
 

--- a/lib/ex_owm/historical_weather/coordinator.ex
+++ b/lib/ex_owm/historical_weather/coordinator.ex
@@ -1,0 +1,40 @@
+defmodule ExOwm.HistoricalWeather.Coordinator do
+  @moduledoc """
+  This module is a GenServer implementation created for handling concurrent
+  worker task coordination.
+  """
+  use GenServer
+  alias ExOwm.HistoricalWeather.Worker
+
+  ## Client API
+  def start_link(options \\ []) do
+    GenServer.start_link(__MODULE__, %{}, options ++ [name: :historical_weather_coordinator])
+  end
+
+  def get_weather(locations, opts) do
+    GenServer.call(:historical_weather_coordinator, {:get_historical_weather, locations, opts})
+  end
+
+  ## Server implementation
+  def init(_) do
+    {:ok, %{}}
+  end
+
+  def handle_call({:get_state}, _from, state) do
+    {:reply, state, state}
+  end
+
+  def handle_call({:get_historical_weather, locations, opts}, _from, _state) do
+    spawn_worker_tasks(locations, opts)
+  end
+
+  defp spawn_worker_tasks(locations, opts) do
+    worker_tasks =
+      Enum.map(locations, fn location ->
+        Task.async(Worker, :get_historical_weather, [location, opts])
+      end)
+
+    results = Enum.map(worker_tasks, fn task -> Task.await(task) end)
+    {:reply, results, results}
+  end
+end

--- a/lib/ex_owm/historical_weather/worker.ex
+++ b/lib/ex_owm/historical_weather/worker.ex
@@ -1,0 +1,27 @@
+defmodule ExOwm.HistoricalWeather.Worker do
+  @moduledoc """
+  Five Day Forecast Worker task implementation.
+  """
+  alias ExOwm.Api
+  alias ExOwm.Cache
+
+  @doc """
+  Returns five day weather forecast for a specific location and given options.
+  Checks whether request has been already cached, if not it sends the request to
+  OWM API and caches it with specific TTL.
+  """
+  @spec get_historical_weather(map, key: atom) :: map
+  def get_historical_weather(location, opts) do
+    case Cache.get("historical_weather: #{inspect(location)}") do
+      # If location wasn't cached within last 10 minutes, call OWM API
+      nil ->
+        result = Api.send_and_parse_request(:get_historical_weather, location, opts)
+        Cache.put("historical_weather: #{inspect(location)}", result, ttl: :timer.minutes(10)) # TODO: can we increase this ttl based on the current time? Because it always returns the whole day.
+        result
+
+      # If location was cached, return it
+      location ->
+        location
+    end
+  end
+end

--- a/lib/ex_owm/request_string.ex
+++ b/lib/ex_owm/request_string.ex
@@ -38,6 +38,10 @@ defmodule ExOwm.RequestString do
   defp add_prefix_substring({:get_sixteen_day_forecast, location, opts}),
     do: {"api.openweathermap.org/data/2.5/forecast/daily", location, opts}
 
+  # History call.
+  defp add_prefix_substring({:get_historical_weather, location, opts}),
+    do: {"api.openweathermap.org/data/2.5/onecall/timemachine", location, opts}
+
   # Call by city name and ISO 3166 country code.
   defp add_location_substring({string, %{city: city, country_code: country_code}, opts}),
     do: {string <> "?q=#{city},#{country_code}", opts}
@@ -50,7 +54,11 @@ defmodule ExOwm.RequestString do
   defp add_location_substring({string, %{id: id}, opts}),
     do: {string <> "?id=#{id}", opts}
 
-  # Call by geo coordinates.
+  # Call by geo coordinates with datetime string
+  defp add_location_substring({string, %{lat: lat, lon: lon, dt: dt}, opts}),
+       do: {string <> "?lat=#{lat}&lon=#{lon}&dt=#{dt}", opts}
+
+  # Call by geo coordinates
   defp add_location_substring({string, %{lat: lat, lon: lon}, opts}),
     do: {string <> "?lat=#{lat}&lon=#{lon}", opts}
 

--- a/lib/ex_owm/supervisor.ex
+++ b/lib/ex_owm/supervisor.ex
@@ -16,7 +16,8 @@ defmodule ExOwm.Supervisor do
       worker(ExOwm.CurrentWeather.Coordinator, []),
       worker(ExOwm.Weather.Coordinator, []),
       worker(ExOwm.FiveDayForecast.Coordinator, []),
-      worker(ExOwm.SixteenDayForecast.Coordinator, [])
+      worker(ExOwm.SixteenDayForecast.Coordinator, []),
+      worker(ExOwm.HistoricalWeather.Coordinator, []),
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExOwm.Mixfile do
     [
       app: :ex_owm,
       name: "ExOwm",
-      version: "1.2.1",
+      version: "1.2.2",
       description: "OpenWeatherMap API Elixir client.",
       source_url: @github_url,
       homepage_url: @github_url,

--- a/test/get_historical_weather_test.exs
+++ b/test/get_historical_weather_test.exs
@@ -1,0 +1,52 @@
+defmodule GetHistoricalWeatherTest do
+  use ExUnit.Case
+
+  test ": can get historical one call weather data by latitude and longitude" do
+    # given
+    yesterday = DateTime.utc_now() |> DateTime.add(24 * 60 * 60 * -1, :second) |> DateTime.to_unix()
+    city = %{lat: 52.374031, lon: 4.88969, dt: yesterday}
+    # when
+    result = ExOwm.get_historical_weather([city])
+    # then
+    # check whether a list of maps is returned
+    assert is_list(result)
+    assert result != []
+    {:ok, map} = List.first(result)
+    assert is_map(map)
+    # check whether map has specific keys to confirm that request was successful
+    assert Map.get(map, "current") |> Map.get("temp") > 200 # kelvin, we should be fine here
+    assert Map.get(map, "hourly") |> List.first() |> Map.get("dt") < yesterday  # The first entry should be smaller than what we asked for because it's midnight.
+    assert Map.get(map, "hourly") |> Enum.count() == 24
+  end
+
+  test ": can get historical weather data with get_historical_weather/2 by latitude and longitude with options" do
+    # given
+    yesterday = DateTime.utc_now() |> DateTime.add(24 * 60 * 60 * -1, :second) |> DateTime.to_unix()
+    city = %{lat: 46.514098, lon: 8.326755, dt: yesterday}
+    options = [units: :metric, lang: :de]
+    # when
+    result = ExOwm.get_historical_weather([city], options)
+    # then
+    # check whether a list of maps is returned
+    assert is_list(result)
+    assert result != []
+    {:ok, map} = List.first(result)
+    assert is_map(map)
+    # check whether map has specific keys to confirm that request was successful
+    assert Map.get(map, "current") |> Map.get("temp") < 100 # Celsius, we should be fine here
+    assert Map.get(map, "hourly") |> List.first() |> Map.get("dt") < yesterday  # The first entry should be smaller than what we asked for because it's midnight.
+  end
+
+  test ": Parses errors correctly" do
+    # given
+    city = %{lat: "15", lon: "-2", dt: -200}
+    # when
+    result = ExOwm.get_historical_weather(city)
+    # then
+    # check whether a list of maps is returned
+    assert is_list(result)
+    assert result != []
+    {:error, :not_found, %{"cod" => "400", "message" => "requested time is out of allowed range of 5 days back"}} = List.first(result)
+  end
+
+end


### PR DESCRIPTION
By the way I usually use something like this in my app to convert the strings to atoms in maps:

```
# get the weather inside a function for one location
    [result] = ExOwm.get_weather(%{lat: lat, lon: lon}, units: :metric, lang: Gettext.get_locale() |> String.to_atom())

    case result do
      {:ok, map} -> {:ok, keys_to_atoms(map)}
      x -> x
    end

  def keys_to_atoms([]), do: []
  def keys_to_atoms([h | tail]) do
    [keys_to_atoms(h) | keys_to_atoms(tail)]
  end
  def keys_to_atoms(string_key_map) when is_map(string_key_map) do
    for {key, val} <- string_key_map, into: %{}, do: {String.to_atom(key), keys_to_atoms(val)}
  end
  def keys_to_atoms(value), do: value
```
That way I can call it in the frontend like `weather.current.temp`. Is that something we should add to this library?

Btw here is a screenshot of what your library enabled:
![grafik](https://user-images.githubusercontent.com/2607157/110970110-b52ec000-8359-11eb-90b9-4e0fa0be04ee.png)

